### PR TITLE
タイムゾーンの差異を吸収するために、期間指定する際にテキストではなくDateTimeオブジェクトを指定する

### DIFF
--- a/Service/SalesReportService.php
+++ b/Service/SalesReportService.php
@@ -195,8 +195,8 @@ class SalesReportService
             ->andWhere('o.order_date < :end')
             ->andWhere('o.OrderStatus NOT IN (:excludes)')
             ->setParameter(':excludes', $excludes)
-            ->setParameter(':start', $this->termStart)
-            ->setParameter(':end', $this->termEnd);
+            ->setParameter(':start', new DateTime($this->termStart))
+            ->setParameter(':end', new DateTime($this->termEnd));
 
         log_info('SalesReport Plugin : search parameters ', ['From' => $this->termStart, 'To' => $this->termEnd]);
         $result = [];


### PR DESCRIPTION
- [こちら](https://github.com/EC-CUBE/sales-report-plugin/issues/47)の方法ではうまく行かず
- 期間をテキストではなくDateTimeオブジェクトで指定する方法で対応